### PR TITLE
add .gitignore and add files from build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+Curl.c
+Curl.o
+MYMETA.json
+MYMETA.yml
+Makefile
+Makefile.old
+blib/
+curlopt-constants.c
+pm_to_blib


### PR DESCRIPTION
a few files are created in the build process, i _assume_ they are
not to be version so have added them to the newly created .gitignore
file so they don't accidently get checked in
