### PR TITLE
Exclude further constants for curl 7.50.2 and newer and use . for @INC

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,7 @@
 # Makefile.PL for Perl module WWW::Curl
 # Check out the README file for more information.
 
+use lib ".";
 use inc::Module::Install;
 
 name			'WWW-Curl';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -137,7 +137,7 @@ sub parse_constants {
         close H;
 
         for my $e (sort @syms) {
-            if ($e =~ /(OBSOLETE|^CURL_EXTERN|_LAST\z|_LASTENTRY\z)/) {
+            if ($e =~ /(OBSOLETE|^CURL_EXTERN|^CURL_STRICTER\z|^CURL_DID_MEMORY_FUNC_TYPEDEFS\z|_LAST\z|_LASTENTRY\z)/) {
                 next;
             }
             my ($group) = $e =~ m/^([^_]+_)/;


### PR DESCRIPTION
Adds
- CURL_DID_MEMORY_FUNC_TYPEDEFS
- CURL_STRICTER

See <https://github.com/szbalint/WWW--Curl/issues/16>, <https://rt.cpan.org/Public/Bug/Display.html?id=117793>.
