### PR TITLE
Fix issues with latest versions of curl

### DIFF
--- a/Curl.xs
+++ b/Curl.xs
@@ -18,6 +18,10 @@
 #include <curl/easy.h>
 #include <curl/multi.h>
 
+#if defined(__CURL_MULTI_H) && !defined(CURLINC_MULTI_H)
+#   define CURLINC_MULTI_H
+#endif
+
 #define header_callback_func writeheader_callback_func
 
 /* Do a favor for older perl versions */
@@ -70,7 +74,7 @@ typedef struct {
 
 
 typedef struct {
-#ifdef __CURL_MULTI_H
+#ifdef CURLINC_MULTI_H
     struct CURLM *curlm;
 #else
     struct void *curlm;
@@ -232,7 +236,7 @@ static perl_curl_multi * perl_curl_multi_new()
 {
     perl_curl_multi *self;
     Newxz(self, 1, perl_curl_multi);
-#ifdef __CURL_MULTI_H
+#ifdef CURLINC_MULTI_H
     self->curlm=curl_multi_init();
 #else
     croak("curl version too old to support curl_multi_init()");
@@ -243,7 +247,7 @@ static perl_curl_multi * perl_curl_multi_new()
 /* delete the multi */
 static void perl_curl_multi_delete(perl_curl_multi *self)
 {
-#ifdef __CURL_MULTI_H
+#ifdef CURLINC_MULTI_H
     if (self->curlm) 
         curl_multi_cleanup(self->curlm);
     Safefree(self);
@@ -1053,7 +1057,7 @@ curl_multi_add_handle(curlm, curl)
     WWW::Curl::Multi curlm
     WWW::Curl::Easy curl
     CODE:
-#ifdef __CURL_MULTI_H
+#ifdef CURLINC_MULTI_H
         curl_multi_add_handle(curlm->curlm, curl->curl);
 #endif
 
@@ -1062,7 +1066,7 @@ curl_multi_remove_handle(curlm, curl)
     WWW::Curl::Multi curlm
     WWW::Curl::Easy curl
     CODE:
-#ifdef __CURL_MULTI_H
+#ifdef CURLINC_MULTI_H
         curl_multi_remove_handle(curlm->curlm, curl->curl);
 #endif
 
@@ -1137,7 +1141,7 @@ curl_multi_perform(self)
     PREINIT:
         int remaining;
     CODE:
-#ifdef __CURL_MULTI_H
+#ifdef CURLINC_MULTI_H
         while(CURLM_CALL_MULTI_PERFORM ==
             curl_multi_perform(self->curlm, &remaining));
 	    RETVAL = remaining;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -137,7 +137,7 @@ sub parse_constants {
         close H;
 
         for my $e (sort @syms) {
-            if ($e =~ /(OBSOLETE|^CURL_EXTERN|_LAST\z|_LASTENTRY\z)/) {
+            if ($e =~ /(OBSOLETE|^CURL_EXTERN|^CURL_WIN32\z|^CURLOPT\z|^CURL_STRICTER\z|^CURL_DID_MEMORY_FUNC_TYPEDEFS\z|_LAST\z|_LASTENTRY\z)/) {
                 next;
             }
             my ($group) = $e =~ m/^([^_]+_)/;


### PR DESCRIPTION
This has been tested on ArchLinux with curl 7.70.0. It should be backwards compatible with older versions of curl that used `__CURL_MULTI_H`. It also fixes some symbol issues where `CURL_WIN32` and `CURLOPT` were being defined and uses the latest regexp from curl's [tests/symbol-scan.pl](https://github.com/curl/curl/blob/master/tests/symbol-scan.pl).

```
"/usr/bin/perl" "-Iinc" -MExtUtils::Command::MM -e 'cp_nonempty' -- Curl.bs blib/arch/auto/WWW/Curl/Curl.bs 644
PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'inc', 'blib/lib', 'blib/arch')" t/*.t
t/00constants.t ........... ok       
t/01basic.t ............... ok     
t/02callbacks.t ........... ok   
t/04abort-test.t .......... ok   
t/05progress.t ............ ok     
t/06http-post.t ........... skipped: Not performing http POST/upload tests
t/07ftp-upload.t .......... skipped: Not performing ftp upload tests
t/08ssl.t ................. ok     
t/09times.t ............... ok     
t/10errbuf.t .............. ok     
t/13slowleak.t ............ skipped: Not performing slow leakage regression test
t/14duphandle.t ........... ok     
t/15duphandle-callback.t .. ok     
t/16formpost.t ............ skipped: Not performing POST
t/17slist.t ............... skipped: Not performing printenv cgi tests
t/18twinhandles.t ......... ok     
t/19multi.t ............... ok     
t/20undefined_subs.t ...... ok   
t/21write-to-scalar.t ..... ok    
t/meta.t .................. skipped: Test::CPAN::Meta required for testing META.yml
t/pod-coverage.t .......... skipped: Test::Pod::Coverage 1.04 required for testing POD coverage
t/pod.t ................... skipped: Test::Pod 1.14 required for testing POD
All tests successful.
Files=22, Tests=820, 10 wallclock secs ( 0.21 usr  0.03 sys +  2.17 cusr  0.46 csys =  2.87 CPU)
Result: PASS
```